### PR TITLE
3-feat-deviceCRUD

### DIFF
--- a/server/ttalkkag/src/main/java/wap/ttalkkag/device/ChangeDeviceSettingDTO.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/device/ChangeDeviceSettingDTO.java
@@ -1,0 +1,13 @@
+package wap.ttalkkag.device;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/*기기의 이름을 변경하기 위한 DTO*/
+@Getter
+@Setter
+public class ChangeDeviceSettingDTO {
+    private String type;
+    private Long deviceId;
+    private String newName;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeleteDeviceDTO.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeleteDeviceDTO.java
@@ -1,0 +1,12 @@
+package wap.ttalkkag.device;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/*기기 삭제를 위한 dto*/
+@Getter
+@Setter
+public class DeleteDeviceDTO {
+    private String type;
+    private Long deviceId;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeviceController.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeviceController.java
@@ -1,0 +1,36 @@
+package wap.ttalkkag.device;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import wap.ttalkkag.domain.User;
+import wap.ttalkkag.repository.UserRepository;
+
+@RestController
+@RequestMapping("/device")
+@RequiredArgsConstructor
+public class DeviceController {
+    private final DeviceService deviceService;
+
+    /*등록된 디바이스 목록 불러오기
+    로그인 기능 도입 후 확장 위해 userId에 연결된 기기 불러옴*/
+    @GetMapping("/{userId}/list")
+    public ResponseEntity<User> getDeviceList(@PathVariable("userId") Long userId) {
+        User user = deviceService.getRegisteredDevices(userId);
+        return ResponseEntity.ok(user);
+    }
+    /*디바이스의 이름 변경하기*/
+    @PatchMapping("/{userId}/change-name")
+    public ResponseEntity<Void> changeDeviceName(@PathVariable("userId") Long userId,
+                                   @RequestBody ChangeDeviceSettingDTO request) {
+        deviceService.updateDeviceName(userId, request);
+        return ResponseEntity.ok().build();
+    }
+    /*디바이스 삭제하기*/
+    @DeleteMapping("/{userId}/delete")
+    public ResponseEntity<Void> deleteDevice(@PathVariable("userId") Long userId,
+                                             @RequestBody DeleteDeviceDTO request) {
+        deviceService.deleteDevice(userId, request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeviceService.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeviceService.java
@@ -1,0 +1,84 @@
+package wap.ttalkkag.device;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wap.ttalkkag.domain.Button;
+import wap.ttalkkag.domain.Dial;
+import wap.ttalkkag.domain.Door;
+import wap.ttalkkag.domain.User;
+import wap.ttalkkag.repository.ButtonRepository;
+import wap.ttalkkag.repository.DialRepository;
+import wap.ttalkkag.repository.DoorRepository;
+import wap.ttalkkag.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class DeviceService {
+    private final UserRepository userRepository;
+    private final ButtonRepository buttonRepository;
+    private final DialRepository dialRepository;
+    private final DoorRepository doorRepository;
+
+    /*해당 userId에 연관된 디바이스 목록을 가져옴*/
+    public User getRegisteredDevices(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("User not found"));
+    }
+
+    /*device의 이름을 변경
+    TODO: 현재 user가 설정하고자 하는 device의 변경 권한을 가지고 있는지 확인하는 코드를 리팩토링
+          중복된 코드도 많음.*/
+    public void updateDeviceName(Long userId, ChangeDeviceSettingDTO request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+
+        Long deviceId = request.getDeviceId();
+        String newName = request.getNewName();
+        switch (request.getType()) {
+            case "button" -> {
+                Button button = buttonRepository.findById(deviceId).orElseThrow(() -> new RuntimeException("Device not found"));
+                if (!button.getUser().equals(user)) throw new RuntimeException("No change permission");
+
+                button.setName(newName);
+                buttonRepository.save(button);
+            }
+            case "dial" -> {
+                Dial dial = dialRepository.findById(deviceId).orElseThrow(() -> new RuntimeException("Device not found"));
+                if (!dial.getUser().equals(user)) throw new RuntimeException("No change permission");
+                dial.setName(newName);
+                dialRepository.save(dial);
+            }
+            case "door" -> {
+                Door door = doorRepository.findById(deviceId).orElseThrow(() -> new RuntimeException("Device not found"));
+                if (!door.getUser().equals(user)) throw new RuntimeException("No change permission");
+                door.setName(newName);
+                doorRepository.save(door);
+            }
+            default -> throw new IllegalArgumentException("Wrong device type");
+        }
+    }
+    /*기기 삭제, 삭제 권한이 있는지 확인 후 삭제*/
+    public void deleteDevice(Long userId, DeleteDeviceDTO request) {
+        User user = userRepository.findById(userId).orElseThrow(() -> new RuntimeException("User not found"));
+
+        Long deviceId = request.getDeviceId();
+        switch(request.getType()) {
+            case "button" -> {
+                Button button = buttonRepository.findById(deviceId).orElseThrow(() -> new RuntimeException("Device not found"));
+                if (!button.getUser().equals(user)) throw new RuntimeException("No change permission");
+                buttonRepository.delete(button);
+            }
+            case "dial" -> {
+                Dial dial = dialRepository.findById(deviceId).orElseThrow(() -> new RuntimeException("Device not found"));
+                if (!dial.getUser().equals(user)) throw new RuntimeException("No change permission");
+                dialRepository.delete(dial);
+            }
+            case "door" -> {
+                Door door = doorRepository.findById(deviceId).orElseThrow(() -> new RuntimeException("Device not found"));
+                if (!door.getUser().equals(user)) throw new RuntimeException("No change permission");
+                doorRepository.delete(door);
+            }
+            default -> throw new IllegalArgumentException("Wrong device type");
+        }
+    }
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Button.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Button.java
@@ -1,0 +1,33 @@
+package wap.ttalkkag.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "buttons")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Button {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private Boolean state;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id",nullable = false)
+    @JsonIgnore
+    private User user;
+
+    @OneToMany(mappedBy = "button")
+    private List<Trigger> triggers;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Dial.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Dial.java
@@ -1,0 +1,34 @@
+package wap.ttalkkag.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "dials")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Dial {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private Boolean state;
+    private Integer step;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @JsonIgnore
+    private User user;
+
+    @OneToMany(mappedBy = "dial")
+    private List<Trigger> triggers;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Door.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Door.java
@@ -1,0 +1,33 @@
+package wap.ttalkkag.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "doors")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Door {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+    private Boolean state;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    @JsonIgnore
+    private User user;
+
+    @OneToMany(mappedBy = "door", cascade = CascadeType.ALL)
+    private List<Trigger> triggers;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Trigger.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Trigger.java
@@ -1,0 +1,34 @@
+package wap.ttalkkag.domain;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "triggers")
+@AllArgsConstructor
+@NoArgsConstructor
+public class Trigger {
+
+    @EmbeddedId
+    private TriggerId id;
+
+    private String name;
+
+    @ManyToOne
+    @MapsId("doorId")
+    @JoinColumn(name = "door_id", insertable = false, updatable = false)
+    private Door door;
+
+    @ManyToOne
+    @JoinColumn(name = "device_id", nullable = false, insertable = false, updatable = false)
+    private Button button;
+
+    @ManyToOne
+    @JoinColumn(name = "device_id", nullable = false, insertable = false, updatable = false)
+    private Dial dial;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/TriggerId.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/TriggerId.java
@@ -1,0 +1,52 @@
+package wap.ttalkkag.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Embeddable;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import wap.ttalkkag.domain.enums.DeviceType;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+@Embeddable
+@Getter
+@Setter
+public class TriggerId implements Serializable {
+    @Column(name = "door_id")
+    private Long doorId;
+
+    @Column(name = "device_id")
+    private Long deviceId;
+
+    @Column(name = "device_type")
+    @Enumerated(EnumType.STRING)
+    private DeviceType deviceType;
+
+    public TriggerId() {}
+
+    public TriggerId(Long doorId, Long deviceId, DeviceType deviceType) {
+        this.doorId = doorId;
+        this.deviceId = deviceId;
+        this.deviceType = deviceType;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        TriggerId that = (TriggerId) o;
+        return Objects.equals(doorId, that.doorId) &&
+                Objects.equals(deviceId, that.deviceId) &&
+                Objects.equals(deviceType, that.deviceType);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(doorId, deviceId, deviceType);
+    }
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/User.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/User.java
@@ -1,0 +1,34 @@
+package wap.ttalkkag.domain;
+
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Entity
+@Getter
+@Setter
+@Table(name = "users")
+@NoArgsConstructor
+@AllArgsConstructor
+public class User {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String clientId;
+    private String brokerUrl;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Button> buttons;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Dial> dials;
+
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL)
+    private List<Dial> doors;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/enums/DeviceType.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/enums/DeviceType.java
@@ -1,0 +1,7 @@
+package wap.ttalkkag.domain.enums;
+
+public enum DeviceType {
+    BUTTON,
+    DIAL,
+    DOOR
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttController.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttController.java
@@ -14,19 +14,24 @@ public class MqttController {
         this.mqttSubscriberService = mqttSubscriberService;
     }
 
-    //TODO: return 형식 합의 후 변경 필요
-    //토픽, 메시지 지정 후 발행
+    //새로운 기기 등록
+    @PostMapping("/new-device")
+    public String registerDevice() {
+        return mqttSubscriberService.subscribeToRegistrationTopic();
+    }
+
+    /* //토픽, 메시지 지정 후 발행
     @PostMapping("/publish")
     public String publishMessage(@RequestBody MqttPublishRequestDTO request) {
         mqttPublisherSevice.publishMessage(request.getTopic(), request.getMessage());
         return "Message sent to topic: " + request.getTopic();
     }
 
-    //TODO: return 형식 합의 후 변경 필요
+
     //구독 중인 토픽 내에 최신 메시지 return
     @GetMapping("/last-message")
     public String getLastReceivedMessage() {
         String lastMessage = mqttSubscriberService.getLastMessage();
         return lastMessage != null ? "Last received message: " + lastMessage : "No messages received yet.";
-    }
+    } */
 }

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttPublisherSevice.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttPublisherSevice.java
@@ -1,17 +1,15 @@
 package wap.ttalkkag.mqtt;
 
+import lombok.RequiredArgsConstructor;
 import org.eclipse.paho.client.mqttv3.MqttClient;
 import org.eclipse.paho.client.mqttv3.MqttException;
 import org.eclipse.paho.client.mqttv3.MqttMessage;
 import org.springframework.stereotype.Service;
 
 @Service
+@RequiredArgsConstructor
 public class MqttPublisherSevice {
     private final MqttClient mqttClient;
-
-    public MqttPublisherSevice(MqttClient mqttClient) {
-        this.mqttClient = mqttClient;
-    }
 
     //지정 topic에 message를 전송
     public void publishMessage(String topic, String message) {

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttSubscriberService.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttSubscriberService.java
@@ -1,8 +1,18 @@
 package wap.ttalkkag.mqtt;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import org.eclipse.paho.client.mqttv3.*;
 import org.springframework.stereotype.Service;
+import wap.ttalkkag.domain.Button;
+import wap.ttalkkag.domain.Dial;
+import wap.ttalkkag.domain.Door;
+import wap.ttalkkag.domain.User;
+import wap.ttalkkag.repository.ButtonRepository;
+import wap.ttalkkag.repository.DialRepository;
+import wap.ttalkkag.repository.DoorRepository;
+import wap.ttalkkag.repository.UserRepository;
 
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -11,13 +21,96 @@ import java.util.concurrent.LinkedBlockingQueue;
 @Service
 public class MqttSubscriberService implements MqttCallback {
     private final MqttClient mqttClient;
+    private final ButtonRepository buttonRepository;
+    private final DialRepository dialRepository;
+    private final UserRepository userRepository;
     private final BlockingQueue<String> messageQueue = new LinkedBlockingQueue<>();
+    private final DoorRepository doorRepository;
 
-    public MqttSubscriberService(MqttClient mqttClient) {
+    public MqttSubscriberService(MqttClient mqttClient, ButtonRepository buttonRepository,
+                                 DialRepository dialRepository, UserRepository userRepository, DoorRepository doorRepository) {
         this.mqttClient = mqttClient;
+        this.buttonRepository = buttonRepository;
+        this.dialRepository = dialRepository;
+        this.userRepository = userRepository;
+        this.doorRepository = doorRepository;
     }
 
-    //애플리케이션이 실행되면 자동으로 실행되어 {topicFilter}를 구독
+    public String subscribeToRegistrationTopic() {
+        String topic = "hub/connect";
+
+        try {
+            mqttClient.subscribe(topic, (t, message) -> {
+                String payload = new String(message.getPayload());
+                System.out.println("기기 등록 요청 수신: " + payload);
+
+                //JSON 파싱
+                ObjectMapper objectMapper = new ObjectMapper();
+                JsonNode jsonNode = objectMapper.readTree(payload);
+                String name = jsonNode.get("name").asText();
+                String type = jsonNode.get("type").asText();
+                String serial = jsonNode.get("serial").asText();
+                //DB에 저장
+                Long deviceId = saveDeviceToDB(name, type);
+                //등록 응답을 회신
+                sendDeviceApprovalResponse(deviceId, type, serial);
+
+                mqttClient.unsubscribe(topic);
+            });
+            return "기기 등록 요청 대기 중...";
+        } catch (Exception e) {
+            e.printStackTrace();
+            return "기기 등록 실패";
+        }
+    }
+    //db에 기기를 저장하고 db내 ID를 추출하여 반환
+    private Long saveDeviceToDB(String name, String type) {
+        User user = userRepository.findById(1L).orElseThrow(() -> new RuntimeException("User not found"));
+        if ("button".equalsIgnoreCase(type)) {
+            Button button = new Button();
+            button.setName(name);
+            button.setState(false);    //state는 필요한지 잘 모르겠음
+            button.setUser(user);
+            buttonRepository.save(button);
+            return button.getId();
+        } else if ("dial".equalsIgnoreCase(type)) {
+            Dial dial = new Dial();
+            dial.setName(name);
+            dial.setState(false);  //state는 필요한지 잘 모르겠음
+            dial.setStep(0);
+            dial.setUser(user);
+            dialRepository.save(dial);
+            return dial.getId();
+        } else if ("door".equalsIgnoreCase(type)) {
+            Door door = new Door();
+            door.setName(name);
+            door.setState(false);
+            door.setUser(user);
+            doorRepository.save(door);
+            return door.getId();
+        } else {
+            throw new IllegalArgumentException("Invalid device type: " + type);
+        }
+    }
+    /*기기 등록 승인 응답을 회신
+    * 그러기 위해 기기는 등록을 요청할 때 serial을 보냄
+    * 서버에게 승인 응답을 받을 토픽을 구독하고 있어야 함
+    * 서버는 payload로 deviceId를 보내고 기기는 해당 deviceId로 토픽을 새로 구독*/
+    private void sendDeviceApprovalResponse(Long deviceId, String type, String serial) {
+        try {
+            String responseTopic = "hub/connect/response/" + serial;
+            String responseMessage = "{ \"status\": \"approved\", \"deviceId\": " + deviceId
+                    + ", \"type\": \"" + type + "\" }";
+
+            mqttClient.publish(responseTopic, new MqttMessage(responseMessage.getBytes()));
+            System.out.println("기기 등록 승인 응답 발행: " + responseMessage);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
+   /** //애플리케이션이 실행되면 자동으로 실행되어 {topicFilter}를 구독
     @PostConstruct
     public void subscribeToTopic() {
         try {
@@ -27,7 +120,7 @@ public class MqttSubscriberService implements MqttCallback {
         } catch (MqttException e) {
             e.printStackTrace();
         }
-    }
+    } **/
 
     //Mqtt 연결이 끊어졌을 시 로그 출력
     //TODO: 자동 재연결 로직을 추가

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/ButtonRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/ButtonRepository.java
@@ -1,0 +1,9 @@
+package wap.ttalkkag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import wap.ttalkkag.domain.Button;
+
+@Repository
+public interface ButtonRepository extends JpaRepository<Button, Long> {
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DialRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DialRepository.java
@@ -1,0 +1,9 @@
+package wap.ttalkkag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import wap.ttalkkag.domain.Dial;
+
+@Repository
+public interface DialRepository extends JpaRepository<Dial, Long> {
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DoorRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DoorRepository.java
@@ -1,0 +1,9 @@
+package wap.ttalkkag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import wap.ttalkkag.domain.Door;
+
+@Repository
+public interface DoorRepository extends JpaRepository<Door, Long> {
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/TriggerRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/TriggerRepository.java
@@ -1,0 +1,9 @@
+package wap.ttalkkag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import wap.ttalkkag.domain.Trigger;
+
+@Repository
+public interface TriggerRepository extends JpaRepository<Trigger, Long> {
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/UserRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/UserRepository.java
@@ -1,0 +1,12 @@
+package wap.ttalkkag.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import wap.ttalkkag.domain.User;
+
+import java.util.Optional;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findById(Long Id);
+}

--- a/server/ttalkkag/src/main/resources/application-local.properties
+++ b/server/ttalkkag/src/main/resources/application-local.properties
@@ -3,7 +3,7 @@ spring.datasource.url=jdbc:mariadb://localhost:3306/TTALKGGAK
 spring.datasource.username=root
 spring.datasource.password=rkdtlr12()
 
-spring.jpa.hibernate.ddl-auto=create
+spring.jpa.hibernate.ddl-auto=none
 spring.jpa.show-sql=true
 spring.jpa.properties.hibernate.format_sql=true
 


### PR DESCRIPTION
## #️⃣연관된 이슈

#13

## 📝작업 내용

1. 디바이스 목록 불러오기
 userId에 연결된 button, dial, door 목록을 json 형식으로 넘김.
 우리 서비스는 로그인 기능 도입 전까지 유저가 한명이므로 userId는 1로 고정해서 요청하면 될 것
2. 디바이스 등록
 등록 코드는 mqtt 패키지 내에 있음.
 토픽 hub/connect를 구독하여 등록 요청 메시지를 받음.
 등록 과정은 노션 기능 명세 페이지에서 확인 부탁드림.
 등록이 되면 해당 기기에 등록되었다는 메시지를 hub/connect/response/{serial} 토픽으로 회신함.
  mqtt 통신 연습하던 클래스에 작성하여, 클래스 분할이 애매함.
  추후에 리팩토링 하도록 하겠음.
3. 디바이스 삭제

4. 디바이스 이름 변경

## 중점적으로 리뷰받고 싶은 부분(선택)
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?


## 논의하고 싶은 부분(선택)
 우선 기기 등록 과정은 노션에 정리한대로 가정하고 개발하였는데, 틀렸다면 리뷰로 부탁드립니다.
 그리고 프론트 요청에 반환하는 값을 지금은 다 성공, 에러 메시지 String으로 보내는데 이대로 괜찮은지?

## 🫡 참고사항
