### PR TITLE
19-feat-버튼-원격-조정-기능

### DIFF
--- a/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttPublisherSevice.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttPublisherSevice.java
@@ -12,15 +12,13 @@ public class MqttPublisherSevice {
     private final MqttClient mqttClient;
 
     //지정 topic에 message를 전송
-    public void publishMessage(String topic, String message) {
+    public void publish(String topic, String payload) {
         try {
-            MqttMessage mqttMessage = new MqttMessage(message.getBytes());
-            //QoS-1: 최소 한번 전송되는 것을 보장
-            mqttMessage.setQos(1);
-            mqttClient.publish(topic, mqttMessage);
-            System.out.println("Published message: " + message);
-        } catch (MqttException e) {
-            e.printStackTrace();
+            MqttMessage message = new MqttMessage(payload.getBytes());
+            message.setQos(1);
+            mqttClient.publish(topic, message);
+        } catch (MqttException e){
+            throw new RuntimeException("MQTT publish failed", e);
         }
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#21

## 📝작업 내용

버튼 클릭커에 버튼을 누르라는 MQTT 메시지를 발행.
토픽: server/button_clicker/{client_id}/action
QoS: 1

버튼 클릭커 원격 조정 시 바로 기기가 동작하므로
프론트에 따로 반환하는 바디는 없습니다.

버튼 클릭커를 동작시키기만 하고
버튼 클릭커로 인해 전원이 켜지거나 꺼진 전자기기의 상태는 저장하지 않았습니다.
(버튼 클릭커가 아닌 사용자가 본인 손으로 직접 켜거나 끄는 것을 고려해서)