### PR TITLE
35-feat 디바이스목록페이지 하단 네비게이션바 수정

### DIFF
--- a/client/src/screens/DevicePage/DPage.js
+++ b/client/src/screens/DevicePage/DPage.js
@@ -1,20 +1,27 @@
 import React from "react";
-import { ScrollView, View, Text, StyleSheet } from "react-native";
+import { ScrollView, View } from "react-native";
+import { useBottomTabBarHeight } from "@react-navigation/bottom-tabs";
 import Background from "./components/Background.js";
 import { AppText, styles as appTextStyles } from "./components/AppText.js";
 import DeviceBox from "./components/DeviceBox.js";
+
 const DPage = () => {
+  const tabBarHeight = useBottomTabBarHeight();
+
   return (
     <View style={{ flex: 1 }}>
       <Background />
-      <ScrollView>
-        <View>
-          <AppText style={appTextStyles.text1}>딸깍</AppText>
-          <AppText style={appTextStyles.text2}>쉽고 편한 기기관리</AppText>
-          <AppText style={appTextStyles.text3}>My Devices</AppText>
-          <AppText style={appTextStyles.text4}>내 기기 My Devices</AppText>
-          <DeviceBox />
-        </View>
+      <ScrollView
+        contentContainerStyle={{
+          paddingBottom: tabBarHeight + 10, 
+        }}
+        showsVerticalScrollIndicator={false}
+      >
+        <AppText style={appTextStyles.text1}>딸깍</AppText>
+        <AppText style={appTextStyles.text2}>쉽고 편한 기기관리</AppText>
+        <AppText style={appTextStyles.text3}>My Devices</AppText>
+        <AppText style={appTextStyles.text4}>내 기기 My Devices</AppText>
+        <DeviceBox />
       </ScrollView>
     </View>
   );


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #35

## 📝작업 내용

현재 디바이스박스가 여러개 추가되면
네비게이션바가 마지막 디바이스박스를 가리게 됨
-> 네비게이션바높이 +10만큼 margin을 둬서 해결

![image](https://github.com/user-attachments/assets/eba5371e-8e7d-4212-8323-c26a3aa48579)



## 🫡 참고사항
모르고 35번 이슈내용에 관한 코드를 34번 브랜치에서 작업해서 푸시해버림.. 브랜치는 34번이지만 35번이슈에관한 수정사항들