### PR TITLE
63-feat-트리거 내에서 특정 기기 활성화, 비활성화

### DIFF
--- a/server/ttalkkag/src/main/java/wap/ttalkkag/trigger/ActivateDeviceDTO.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/trigger/ActivateDeviceDTO.java
@@ -1,0 +1,13 @@
+package wap.ttalkkag.trigger;
+
+import lombok.Getter;
+import lombok.Setter;
+
+/*트리거에 기기 추가, 제외(활성화, 비활성화)를 위한 DTO*/
+@Getter
+@Setter
+public class ActivateDeviceDTO {
+    private Long doorId;
+    private Long deviceId;
+    private String deviceType;
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/trigger/TriggerController.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/trigger/TriggerController.java
@@ -1,0 +1,47 @@
+package wap.ttalkkag.trigger;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import wap.ttalkkag.domain.Door;
+import wap.ttalkkag.domain.Trigger;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/trigger")
+@RequiredArgsConstructor
+public class TriggerController {
+    private final TriggerService triggerService;
+
+    /*user의 door_sensor 목록*/
+    @GetMapping("/list")
+    public ResponseEntity<List<Door>> getTriggerList() {
+        Long userId = 1L;
+        List<Door> doors = triggerService.getTriggers(userId);
+        return ResponseEntity.ok(doors);
+    }
+
+    /*트리거 동작 시, 함께 동작할 디바이스 목록
+    * 트리거 목록 페이지에서
+    * 우선 등록된 모든 디바이스 목록을 불러온 후
+    * 해당 api로 트리거에 속한 디바이스들의 타입과 id를 받아서
+    * 위 모든 디바이스 목록 중 표시*/
+    @GetMapping("/{door_id}/active_devices")
+    public ResponseEntity<List<Trigger>> getActiveDevices(@PathVariable("door_id") Long doorId) {
+        List<Trigger> activeDevices = triggerService.getActiveDevices(doorId);
+        return ResponseEntity.ok(activeDevices);
+    }
+    /*트리거에 기기 추가(활성화) */
+    @PostMapping("/activate")
+    public ResponseEntity<Void> activateDevice(@RequestBody ActivateDeviceDTO request) {
+        triggerService.activateDevice(request);
+        return ResponseEntity.ok().build();
+    }
+    /*트리거에서 기기 제외(비활성화)*/
+    @DeleteMapping("/deactivate")
+    public ResponseEntity<Void> deactivateDevice(@RequestBody ActivateDeviceDTO request) {
+        triggerService.deactivateDevice(request);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/trigger/TriggerService.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/trigger/TriggerService.java
@@ -1,0 +1,53 @@
+package wap.ttalkkag.trigger;
+
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import wap.ttalkkag.domain.Door;
+import wap.ttalkkag.domain.Trigger;
+import wap.ttalkkag.domain.TriggerId;
+import wap.ttalkkag.repository.DoorRepository;
+import wap.ttalkkag.repository.TriggerRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class TriggerService {
+    private final DoorRepository doorRepository;
+    private final TriggerRepository triggerRepository;
+
+    /*user의 door_sensor 목록*/
+    public List<Door> getTriggers(Long userId) {
+        return doorRepository.findByUserId(userId);
+    }
+    /*특정 트리거가 동작하면 함께 동작할 디바이스 목록*/
+    public List<Trigger> getActiveDevices(Long triggerId) {
+        return triggerRepository.findByIdDoorId(triggerId);
+    }
+    /*트리거에 기기 추가(활성화) */
+    public void activateDevice(ActivateDeviceDTO request) {
+        TriggerId triggerId = new TriggerId();
+        triggerId.setDoorId(request.getDoorId());
+        triggerId.setDeviceId(request.getDeviceId());
+        triggerId.setDeviceType(request.getDeviceType());
+
+        Trigger trigger = new Trigger();
+        trigger.setId(triggerId);
+
+        triggerRepository.save(trigger);
+    }
+    /*트리거에서 기기 제외(비활성화)*/
+    public void deactivateDevice(ActivateDeviceDTO request) {
+        TriggerId triggerId = new TriggerId();
+        triggerId.setDoorId(request.getDoorId());
+        triggerId.setDeviceId(request.getDeviceId());
+        triggerId.setDeviceType(request.getDeviceType());
+
+        if (triggerRepository.existsById(triggerId)) {
+            triggerRepository.deleteById(triggerId);
+        } else {
+            throw new EntityNotFoundException("Trigger not found");
+        }
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

#63

## 📝작업 내용

트리거가 동작하면 함께 동작할 기기를 지정, 지정 취소할 수 있는 기능 api 작성하였음.

## 논의하고 싶은 부분(선택)
door_id, device_id, device_type을 받아서
해당 기기를 트리거에 대해 활성화, 비활성화를 하는데

이때, door_id에 해당하는 door와
device_id, device_type에 해당하는 디바이스가 실제로 있는지는 확인 없이 동작합니다.
확인하는 코드를 추가 해야할까요?

프론트에서는 서버로부터 받은 디바이스 목록을 참고해서
 door_id, device_id, device_type을 json에 담아 보낼 것이므로
굳이 확인이 필요한가 싶어서 일단 간단하게 코드 작성했습니다.

## 🫡 참고사항
