### PR TITLE
81-feat-디바이스가 속한 트리거 목록 mqtt 통신으로 회신

### DIFF
--- a/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttSubscriberService.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttSubscriberService.java
@@ -2,17 +2,19 @@ package wap.ttalkkag.mqtt;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
 import org.eclipse.paho.client.mqttv3.*;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Service;
-import wap.ttalkkag.domain.Button;
-import wap.ttalkkag.domain.Dial;
-import wap.ttalkkag.domain.Door;
-import wap.ttalkkag.domain.User;
-import wap.ttalkkag.repository.ButtonRepository;
-import wap.ttalkkag.repository.DialRepository;
-import wap.ttalkkag.repository.DoorRepository;
-import wap.ttalkkag.repository.UserRepository;
+import wap.ttalkkag.domain.*;
+import wap.ttalkkag.repository.*;
+
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 
 
 /*Mqtt 콜백 인터페이스*/
@@ -23,15 +25,18 @@ public class MqttSubscriberService implements MqttCallback {
     private final DialRepository dialRepository;
     private final UserRepository userRepository;
     private final DoorRepository doorRepository;
+    private final TriggerRepository triggerRepository;
 
     @Autowired
     public MqttSubscriberService(MqttService mqttService, ButtonRepository buttonRepository,
-                                 DialRepository dialRepository, UserRepository userRepository, DoorRepository doorRepository) {
+                                 DialRepository dialRepository, UserRepository userRepository,
+                                 DoorRepository doorRepository, TriggerRepository triggerRepository) {
         this.mqttService = mqttService;
         this.buttonRepository = buttonRepository;
         this.dialRepository = dialRepository;
         this.userRepository = userRepository;
         this.doorRepository = doorRepository;
+        this.triggerRepository = triggerRepository;
     }
 
     public void subscribeToRegistrationTopic() {
@@ -51,7 +56,35 @@ public class MqttSubscriberService implements MqttCallback {
                     String type = jsonNode.get("type").asText();
                     String clientId = jsonNode.get("clientId").asText();
                     //DB에 저장
-                    saveDeviceToDB(type, clientId);
+                    Long deviceId = saveDeviceToDB(type, clientId);
+                    /*이미 DB에 있는 경우, 해당 기기가 속한 트리거 목록을 반환*/
+                    if (deviceId != 0) {
+                        /*device가 속한 트리거 id 목록
+                        * TODO: 트리거 종류가 늘어나면 트리거 타입도 고려해야함*/
+                        List<Long> triggerIds = triggerRepository.findDoorIdsByDeviceTypeAndDeviceId(type, deviceId);
+                        System.out.println("Trigger IDs: " + triggerIds);
+                        /*위 id 목록으로 트리거 client_id 목록 찾음*/
+                        List<String> triggerClientIds = doorRepository.findClientIdsByIds(triggerIds);
+                        System.out.println("Trigger된 Door IDs로 검색한 clientId 목록: " + triggerClientIds);
+                        /*client_type 목록 구성
+                        * 현재는 door_sensor만 대입*/
+                        List<String> clientTypes = triggerClientIds.stream()
+                                .map(id -> "door_sensor")
+                                .toList();
+                        /*JSON 구성*/
+                        Map<String, List<String>> payloadMap = new HashMap<>();
+                        payloadMap.put("clientType", clientTypes);
+                        payloadMap.put("clientId", triggerClientIds);
+
+                        String responseTopic = "server/triggers/" + type + "/" + clientId;
+                        String responsePayload = objectMapper.writeValueAsString(payloadMap);
+                        System.out.println(responseTopic);
+                        System.out.println(responsePayload);
+                        MqttMessage responseMessage = new MqttMessage(responsePayload.getBytes(StandardCharsets.UTF_8));
+                        responseMessage.setQos(1);
+
+                        client.publish(responseTopic, responseMessage);
+                    }
                 });
             } else {
                 System.err.println("MQTT 브로커에 연결되지 않음. 구독 실패");
@@ -61,24 +94,29 @@ public class MqttSubscriberService implements MqttCallback {
         }
     }
     //db에 기기를 저장하고 db내 ID를 추출하여 반환
-    private void saveDeviceToDB(String type, String clientId) {
+    private Long saveDeviceToDB(String type, String clientId) {
         User user = userRepository.findById(1L).orElseThrow(() -> new RuntimeException("User not found"));
         switch (type.toLowerCase()) {
             case "button_clicker" -> {
-                if (buttonRepository.existsByClientId(clientId)) {
+                Optional<Button> existing = buttonRepository.findByClientId(clientId);
+                if (existing.isPresent()) {
                     System.out.println("이미 등록된 기기입니다.");
-                    return;
+                    /*트리거 목록을 찾기 위한 device_id 반환*/
+                    return existing.get().getId();
                 }
                 Button button = new Button();
                 button.setName("button clicker");
                 button.setUser(user);
                 button.setClientId(clientId);
                 buttonRepository.save(button);
+                return 0L;
             }
             case "dial_actuator" -> {
-                if (dialRepository.existsByClientId(clientId)) {
+                Optional<Dial> existing = dialRepository.findByClientId(clientId);
+                if (existing.isPresent()) {
                     System.out.println("이미 등록된 기기입니다.");
-                    return;
+                    /*트리거 목록을 찾기 위한 device_id 반환*/
+                    return existing.get().getId();
                 }
                 Dial dial = new Dial();
                 dial.setName("dial actuator");
@@ -86,17 +124,20 @@ public class MqttSubscriberService implements MqttCallback {
                 dial.setUser(user);
                 dial.setClientId(clientId);
                 dialRepository.save(dial);
+                return 0L;
             }
             case "door_sensor" -> {
                 if (doorRepository.existsByClientId(clientId)) {
                     System.out.println("이미 등록된 기기입니다.");
-                    return;
+                    /*door_sensor은 트리거이므로 device_id 반환 X*/
+                    return 0L;
                 }
                 Door door = new Door();
                 door.setName("door sensor");
                 door.setUser(user);
                 door.setClientId(clientId);
                 doorRepository.save(door);
+                return 0L;
             }
             default -> throw new IllegalArgumentException("틀린 디바이스 타입");
         }

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/ButtonRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/ButtonRepository.java
@@ -4,7 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import wap.ttalkkag.domain.Button;
 
+import java.util.Optional;
+
 @Repository
 public interface ButtonRepository extends JpaRepository<Button, Long> {
     boolean existsByClientId(String clientId);
+
+    Optional<Button> findByClientId(String clientId);
 }

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DialRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DialRepository.java
@@ -4,7 +4,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 import wap.ttalkkag.domain.Dial;
 
+import java.util.Optional;
+
 @Repository
 public interface DialRepository extends JpaRepository<Dial, Long> {
     boolean existsByClientId(String clientId);
+
+    Optional<Dial> findByClientId(String clientId);
 }

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DoorRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/DoorRepository.java
@@ -1,6 +1,8 @@
 package wap.ttalkkag.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import wap.ttalkkag.domain.Door;
 import wap.ttalkkag.domain.User;
@@ -15,4 +17,7 @@ public interface DoorRepository extends JpaRepository<Door, Long> {
 
     /*user_id에 속한 door_sensor 목록*/
     List<Door> findByUserId(Long userId);
+
+    @Query("SELECT d.clientId FROM Door d WHERE d.id IN :triggerIds")
+    List<String> findClientIdsByIds(@Param("triggerIds") List<Long> triggerIds);
 }

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/repository/TriggerRepository.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/repository/TriggerRepository.java
@@ -1,6 +1,8 @@
 package wap.ttalkkag.repository;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 import wap.ttalkkag.domain.Trigger;
 import wap.ttalkkag.domain.TriggerId;
@@ -10,4 +12,8 @@ import java.util.List;
 @Repository
 public interface TriggerRepository extends JpaRepository<Trigger, TriggerId> {
     List<Trigger> findByIdDoorId(Long doorId);
+
+    @Query("SELECT t.door.id FROM Trigger t WHERE t.id.deviceType = :deviceType AND t.id.deviceId = :deviceId")
+    List<Long> findDoorIdsByDeviceTypeAndDeviceId(@Param("deviceType") String deviceType,
+                                                  @Param("deviceId") Long deviceId);
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

#81 

## 📝작업 내용

기존의 디바이스 등록 요청 받는 코드에서
수신한 페이로드에 이미 DB에 등록된 디바이스 내용이 있다면
디바이스가 속한 트리거 목록을 배열로
server/triggers/{client_type}/{client_id} 토픽으로
회신하도록 수정하였습니다.

## 🫡 참고사항
현재 트리거는 door sensor밖에 없기 때문에
clientType배열에는 door_sensor만 값으로 들어가도록 짜두었습니다.
트리거 기기가 추가되면 코드 수정하겠습니다.