### PR TITLE
92-feat-다이얼 스텝 관련 코드 수정 및 작성

### DIFF
--- a/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeviceController.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/device/DeviceController.java
@@ -35,10 +35,10 @@ public class DeviceController {
         deviceService.patchDeviceMemo(request);
         return ResponseEntity.ok().build();
     }
-    /*다이얼 최대 step 설정*/
-    @PatchMapping("/max-step")
+    /*다이얼 step unit 설정*/
+    @PatchMapping("/step-unit")
     public ResponseEntity<Void> patchDialMaxStep(@RequestBody PatchDialMaxStepDTO request) {
-        deviceService.changeDialMaxStep(request);
+        deviceService.changeDialStepUnit(request);
 
         return ResponseEntity.ok().build();
     }

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Dial.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Dial.java
@@ -22,7 +22,8 @@ public class Dial {
 
     private String name;
     private String clientId;
-    private Integer step;
+    private Integer step = 0;
+    private Integer stepUnit = 0;
     private String memo;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Door.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/domain/Door.java
@@ -7,8 +7,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-import java.util.List;
-
 @Entity
 @Getter
 @Setter

--- a/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttSubscriberService.java
+++ b/server/ttalkkag/src/main/java/wap/ttalkkag/mqtt/MqttSubscriberService.java
@@ -57,6 +57,7 @@ public class MqttSubscriberService implements MqttCallback {
                     String clientId = jsonNode.get("clientId").asText();
                     //DB에 저장
                     Long deviceId = saveDeviceToDB(type, clientId);
+                    System.out.println(deviceId);
                     /*이미 DB에 있는 경우, 해당 기기가 속한 트리거 목록을 반환*/
                     if (deviceId != 0) {
                         /*device가 속한 트리거 id 목록


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #이슈번호, #이슈번호

#92 

> 이번 PR에서 작업한 내용을 간략히 설명해주세요(이미지/동영상 첨부 가능)

기존의 다이얼 도메인을 수정해서 현재 step과 step unit을 저장하도록 하였음.

다이얼 조작 시, DB에 이전 스텝 +- step unit 값을 step에 저장하고
DB에 현재 스텝 갱신이 있을 시에만 디바이스에 토픽 발행하도록 하였음.

## 🫡 참고사항
