### PR TITLE
110-feat이름변경 코드수정

### DIFF
--- a/client/src/screens/TriggerPage/TPage.js
+++ b/client/src/screens/TriggerPage/TPage.js
@@ -281,7 +281,14 @@ const cancelDelete = () => {
 
 
   return (
-    <Pressable onPress={() => setLongPressedIndex(null)} style={{ flex: 1 }}>
+    <Pressable
+  onPress={() => {
+    setLongPressedIndex(null);
+    setEditingListIndex(null); // 목록 이름 편집 종료
+    setEditingDeviceIndex(null); // 디바이스 이름 편집 종료
+  }}
+  style={{ flex: 1 }}
+>
       <Background />
       <AppText style={appTextStyles.text1}>TTALKKAG</AppText>
       <AppText style={appTextStyles.text3}>Trigger</AppText>
@@ -314,7 +321,10 @@ const cancelDelete = () => {
                   updated[index] = newName;
                   setLists(updated);
                 }}
-                onSubmit={(finalName) => handleListNameChange(finalName.slice(0, 10), index)}
+                onSubmit={(finalName) => {
+                  handleListNameChange(finalName.slice(0, 10), index);
+                  setEditingListIndex(null);  // 편집 상태 해제
+                }}
                 onLongPress={() => setLongPressedIndex(index)}
                 showDelete={longPressedIndex === index}
                 onDeleteRequest={() => handleDeleteRequest(index)}
@@ -381,7 +391,11 @@ const cancelDelete = () => {
                 updatedSets[selectedIndex][index].name = newName;
                 setDeviceSets(updatedSets);
               }}
-              onSubmit={(finalName) => handleDeviceNameChange(finalName.slice(0, 10), index)}
+              onSubmit={(finalName) => {
+              handleDeviceNameChange(finalName.slice(0, 10), index);
+              setEditingDeviceIndex(null);  // 편집 상태 해제
+              }}
+
             />
           )}
           keyExtractor={(item) => item.deviceId.toString()}

--- a/client/src/screens/TriggerPage/components/TriggerDeviceBox.js
+++ b/client/src/screens/TriggerPage/components/TriggerDeviceBox.js
@@ -56,6 +56,7 @@ const TriggerDeviceBox = ({ item, index, onToggle, isEditing, onEditStart, onNam
               autoCorrect={false}
               autoComplete="off"
               importantForAutofill="no"
+              onBlur={() => onSubmit(item.name)}
             />
           ) : (
             <Text style={styles.name}>{item.name}</Text>

--- a/client/src/screens/TriggerPage/components/TriggerList.js
+++ b/client/src/screens/TriggerPage/components/TriggerList.js
@@ -43,6 +43,7 @@ const TriggerList = ({
             autoCorrect={false}
             autoComplete="off"
             importantForAutofill="no"
+            onBlur={() => onSubmit(text)}
           />
         ) : (
           <Pressable onLongPress={onLongPress}>


### PR DESCRIPTION


## #️⃣연관된 이슈

> ex) #110 

## 📝작업 내용

> 이름변경 이후에도 이름변경기능이 꺼지지 않아서 오류발생. 이름 수정후 엔터키를 누르거나 화면 다른부분을 클릭할 시 이름이 자동저장되고 이름변경기능이 꺼지도록 수정함

![image](https://github.com/user-attachments/assets/db4e69af-8244-480f-9206-f6d3588d61d8)
테스트로 이름 두개 변경해봄 

## 🫡 참고사항
